### PR TITLE
Fix typo: Vierteljahreszeitschrit -> Vierteljahreszeitschrift

### DIFF
--- a/docs/articles_metadata.csv
+++ b/docs/articles_metadata.csv
@@ -88,7 +88,7 @@ sbz-002_1949_67__519_d;Basels neuer Marktplatz; Schweizerische Bauzeitung;10.09.
 sbz-002_1949_67__587_d;Der Neubau des Warenhauses Globus in Zürich; Schweizerische Bauzeitung;15.10.49;de;TRUE;85;650;;
 sbz-002_1949_67__687_d;Schweizerische Vereinigung für Landesplanung; Schweizerische Bauzeitung;10.12.49;de;TRUE;119;410;;
 sbz-002_1949_67__719_d;Städte, wie wir sie wünschen; Schweizerische Bauzeitung;24.12.49;de;TRUE;142;198;;
-sbz-002_1950_68__319_d;Bauen und Wohnen. Vierteljahreszeitschrit, Herausgeber und Verleger Adolf Pfau, Zürich; Schweizerische Bauzeitung;10.06.50;de;TRUE;33;321;;
+sbz-002_1950_68__319_d;Bauen und Wohnen. Vierteljahreszeitschrift, Herausgeber und Verleger Adolf Pfau, Zürich; Schweizerische Bauzeitung;10.06.50;de;TRUE;33;321;;
 sbz-002_1950_68__505_d;Wettbewerb für kirchliche Bauten in Zürich-Witikon; Schweizerische Bauzeitung;16.09.50;de;TRUE;91;968;;
 sbz-002_1951_69__437_d;Die Entwicklung des Zürcher Stadtzentrums I; Schweizerische Bauzeitung;04.08.51;de;FALSE;8;788;;
 sbz-002_1951_69__464_d;Die Entwicklung des Zürcher Stadtzentrums II; Schweizerische Bauzeitung;11.08.51;de;FALSE;10;635;;


### PR DESCRIPTION
Fixed typo in article title: Vierteljahreszeitschrit → Vierteljahreszeitschrift
Resolves #18